### PR TITLE
Fixed #2

### DIFF
--- a/static/mobileStyle.css
+++ b/static/mobileStyle.css
@@ -2,7 +2,7 @@
 @media (max-width: 600px) {
 
   .navbar-brand img {
-    opacity: 0;
+    display: none;
   }
 
   #home {


### PR DESCRIPTION
the navbar brand was overlapping the menu hamburger itself, causing a click to link to #home instead of toggling the collapsed menu
Addressed #2 